### PR TITLE
JENKINS-66041: Fetch marker file and make it available via global var `markerFile`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/inlinepipeline/InlineDefinitionBranchProjectFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/inlinepipeline/InlineDefinitionBranchProjectFactory.java
@@ -50,7 +50,7 @@ public class InlineDefinitionBranchProjectFactory extends AbstractWorkflowBranch
 
 
     @Override protected FlowDefinition createDefinition() {
-        return new InlineFlowDefinition(this.script, this.sandbox);
+        return new InlineFlowDefinition(this.script, this.sandbox, this.markerFile);
     }
 
     @Override public SCMSourceCriteria getSCMSourceCriteria(SCMSource source) {

--- a/src/main/java/org/jenkinsci/plugins/inlinepipeline/InlineFlowDefinition.java
+++ b/src/main/java/org/jenkinsci/plugins/inlinepipeline/InlineFlowDefinition.java
@@ -2,16 +2,18 @@ package org.jenkinsci.plugins.inlinepipeline;
 
 import hudson.Extension;
 import hudson.Util;
-import hudson.model.Action;
-import hudson.model.Descriptor;
-import hudson.model.DescriptorVisibilityFilter;
-import hudson.model.TaskListener;
+import hudson.model.*;
+import jenkins.branch.Branch;
+import jenkins.scm.api.*;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
 import org.jenkinsci.plugins.workflow.flow.FlowDefinitionDescriptor;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.multibranch.BranchJobProperty;
+import org.jenkinsci.plugins.workflow.multibranch.Messages;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 
 import java.util.List;
@@ -20,14 +22,69 @@ class InlineFlowDefinition extends FlowDefinition {
 
     private String script;
     private boolean sandbox;
+    private String markerFile;
+    private String markerFileContent;
 
+    @Deprecated
     public InlineFlowDefinition(String script, boolean sandbox) {
         this.script = script;
         this.sandbox = sandbox;
     }
 
+    public InlineFlowDefinition(String script, boolean sandbox, String markerFile) {
+        this(script, sandbox);
+        this.markerFile = markerFile;
+    }
+
     @Override public FlowExecution create(FlowExecutionOwner handle, TaskListener listener, List<? extends Action> actions) throws Exception {
+        // For backward compatibility - seems like jobs configured prior to that feature will never have this field set until reconfigured
+        if (this.markerFile != null) {
+            Queue.Executable exec = handle.getExecutable();
+            if (!(exec instanceof WorkflowRun)) {
+                throw new IllegalStateException("inappropriate context");
+            }
+            WorkflowRun build = (WorkflowRun) exec;
+            WorkflowJob job = build.getParent();
+            BranchJobProperty property = job.getProperty(BranchJobProperty.class);
+            if (property == null) {
+                throw new IllegalStateException("inappropriate context");
+            }
+            Branch branch = property.getBranch();
+            ItemGroup<?> parent = job.getParent();
+            if (!(parent instanceof WorkflowMultiBranchProject)) {
+                throw new IllegalStateException("inappropriate context");
+            }
+            SCMSource scmSource = ((WorkflowMultiBranchProject) parent).getSCMSource(branch.getSourceId());
+            if (scmSource == null) {
+                throw new IllegalStateException(branch.getSourceId() + " not found");
+            }
+            SCMHead head = branch.getHead();
+            SCMRevision tip = scmSource.fetch(head, listener);
+            if (tip == null) {
+                throw new IllegalStateException(head.getName() + " not found");
+            }
+
+            build.addAction(new SCMRevisionAction(scmSource, tip));
+
+            SCMRevision rev = scmSource.getTrustedRevision(tip, listener);
+            if (!rev.equals(tip)) {
+                throw new IllegalStateException(Messages.ReadTrustedStep__has_been_modified_in_an_untrusted_revis(markerFile));
+            }
+
+            SCMFileSystem fs = SCMFileSystem.of(scmSource, head, rev);
+            if (fs == null) {
+                throw new IllegalStateException("SCMFileSystem not found");
+            }
+
+            this.markerFileContent = fs.child(markerFile).contentAsString();
+            listener.getLogger().println("Obtained " + markerFile + " from " + rev);
+        }
+
         return new CpsFlowDefinition(Util.fixNull(this.script), this.sandbox).create(handle, listener, actions);
+    }
+
+    public String getMarkerFileContent() {
+        return markerFileContent;
     }
 
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/inlinepipeline/InlineFlowVar.java
+++ b/src/main/java/org/jenkinsci/plugins/inlinepipeline/InlineFlowVar.java
@@ -1,0 +1,34 @@
+package org.jenkinsci.plugins.inlinepipeline;
+
+import hudson.AbortException;
+import hudson.Extension;
+import hudson.model.Job;
+import hudson.model.Run;
+import org.jenkinsci.plugins.workflow.cps.CpsScript;
+import org.jenkinsci.plugins.workflow.cps.GlobalVariable;
+import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+
+@Extension public class InlineFlowVar extends GlobalVariable {
+    @Override public String getName() {
+        return "markerFile";
+    }
+
+    @Override public String getValue(CpsScript script) throws Exception {
+        Run<?,?> build = script.$build();
+        if (!(build instanceof WorkflowRun)) {
+            throw new AbortException("‘markerFile’ is not available outside a Pipeline build");
+        }
+        Job<?,?> job = build.getParent();
+        FlowDefinition flow = ((WorkflowJob) job).getDefinition();
+        if (!(flow instanceof InlineFlowDefinition)) {
+            throw new AbortException("‘markerFile’ is not available if marker file recognizer was not used");
+        }
+        String file = ((InlineFlowDefinition) flow).getMarkerFileContent();
+        if (file == null) {
+            throw new AbortException("‘markerFile’ was not available");
+        }
+        return file;
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

This change enables inline-pipeline plugin to read the marker file from repository and allow to access it's content as string in the `Jenkinsfile`.

This also adds `SCMRevisionAction` early in the build which might be needed by some other plugins.

See https://issues.jenkins.io/browse/JENKINS-66041.