### PR TITLE
Modernize plugin, raise core dependency to 2.332.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.7</version>
+        <version>4.42</version>
         <relativePath />
     </parent>
     <artifactId>inline-pipeline</artifactId>
     <version>1.0.2-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.190.1</jenkins.version>
+        <jenkins.version>2.332.3</jenkins.version>
         <java.level>8</java.level>
     </properties>
     <name>Multibranch Pipeline Inline Definition Plugin</name>
@@ -26,33 +26,40 @@
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
       <tag>HEAD</tag>
-  </scm>
+    </scm>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.332.x</artifactId>
+                <version>1461.vb_3c6de28f2b_a_</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-multibranch</artifactId>
-            <version>2.16</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>branch-api</artifactId>
-            <version>2.0.11</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>2.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloudbees-folder</artifactId>
-            <version>6.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.10</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Core dependency is increased to 2.332.3, the lowest LTS release line with the minimum set of implied dependencies.

Increased plugin dependency versions, for no reason other than the switch to BOM:

- `workflow-multibranch` 716.vc692a_e52371b_
- `branch-api` 2.1046.v0ca_37783ecc5
- `cloudbees-folder` 6.729.v2b_9d1a_74d673
- `scm-api` 608.vfa_f971c5a_a_e9
- `structs` 318.va_f3ccb_729b_71